### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/AllieSilverUbisse/6806b608-f64b-4085-8961-b96a0e722f38/01dab4c8-6fa7-4bd2-a021-6ec0f91de6c5/_apis/work/boardbadge/e644b15e-7317-4104-8c44-e011e4a413de)](https://dev.azure.com/AllieSilverUbisse/6806b608-f64b-4085-8961-b96a0e722f38/_boards/board/t/01dab4c8-6fa7-4bd2-a021-6ec0f91de6c5/Microsoft.RequirementCategory)
 # Fraud Detection
 
 ## Getting Super Powers


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#11](https://dev.azure.com/AllieSilverUbisse/6806b608-f64b-4085-8961-b96a0e722f38/_workitems/edit/11). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.